### PR TITLE
Handle pseudo selectors on local classes

### DIFF
--- a/test/test-cases/export-class/expected.css
+++ b/test/test-cases/export-class/expected.css
@@ -2,9 +2,11 @@
 :export {
   exportName: _input__exportName;
 }
+
 ._input__exportName {
   color: green;
 }
+
 ._input__exportName:hover {
   color: red;
 }

--- a/test/test-cases/export-class/expected.css
+++ b/test/test-cases/export-class/expected.css
@@ -5,3 +5,6 @@
 ._input__exportName {
   color: green;
 }
+._input__exportName:hover {
+  color: red;
+}

--- a/test/test-cases/export-class/source.css
+++ b/test/test-cases/export-class/source.css
@@ -1,3 +1,7 @@
 :local(.exportName) {
   color: green;
 }
+
+:local(.exportName):hover {
+  color: red;
+}


### PR DESCRIPTION
Added a failing test and fixed it! 

I've just added a little to the regexp so that something like a `:hover` will still be considered a local class needing to be transformed.

This should also make the tests pass at https://github.com/css-modules/css-modules-loader-core/pull/3
