### PR TITLE
Added failing test case for keyframes/animations

### DIFF
--- a/test/test-cases/export-keyframes/expected.css
+++ b/test/test-cases/export-keyframes/expected.css
@@ -1,9 +1,14 @@
 
 :export {
   fade-in: _input__fade-in;
+  fader: _input__fader;
 }
 @keyframes _input__fade-in {
   from {
     opacity: 0;
   }
+}
+
+_input__fader {
+  animation: _input__fade-in 1s;
 }

--- a/test/test-cases/export-keyframes/source.css
+++ b/test/test-cases/export-keyframes/source.css
@@ -3,3 +3,7 @@
     opacity: 0;
   }
 }
+
+.fader {
+  animation: :local(fade-in) 1s;
+}


### PR DESCRIPTION
Test fails with 

```
CssSyntaxError: /input:8:14: Double colon
      at Context.<anonymous> (test/test-cases.js:34:31)
```

referring to the double-colon in `animation: :local(fade-in) 1s;`
Is this the correct transformation for locally-scoped keyframe references?
