### PR TITLE
expose source css to generateScopedName

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
     let exports = {};
 
     function exportScopedName(name) {
-      let scopedName = generateScopedName(name, css.source.input.from);
+      let scopedName = generateScopedName(name, css.source.input.from, css.source.input.css);
       exports[name] = exports[name] || [];
       if(exports[name].indexOf(scopedName) < 0) {
         exports[name].push(scopedName);
@@ -156,7 +156,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
   };
 });
 
-processor.generateScopedName = function(exportedName, path) {
+processor.generateScopedName = function(exportedName, path, css) {
   let sanitisedPath = path.replace(/\.[^\.\/\\]+$/, '').replace(/[\W_]+/g, '_').replace(/^_|_$/g, '');
   return `_${sanitisedPath}__${exportedName}`;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
   };
 });
 
-processor.generateScopedName = function(exportedName, path, css) {
+processor.generateScopedName = function(exportedName, path) {
   let sanitisedPath = path.replace(/\.[^\.\/\\]+$/, '').replace(/[\W_]+/g, '_').replace(/^_|_$/g, '');
   return `_${sanitisedPath}__${exportedName}`;
 };


### PR DESCRIPTION
This update is necessary for https://github.com/css-modules/css-modulesify/pull/16, but maybe it would make more sense to make this the default behaviour instead of passing in a custom `generateScopedName` function?

This addresses the issue in https://github.com/css-modules/css-modulesify/issues/15 where two css files with the same filename and the same classNames currently override each other.
