### PR TITLE
Absolute paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import postcss from 'postcss';
 import Tokenizer from 'css-selector-tokenizer';
+import { relative, sep } from 'path';
 
 let hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -28,14 +29,22 @@ function getSingleLocalNamesForComposes(selectors) {
   });
 }
 
-const processor = postcss.plugin('postcss-modules-scope', function(options) {
+/**
+ * @param  {object}   options
+ * @param  {function} options.generateScopedName
+ * @param  {string}   options.rootDir
+ * @return {function}
+ */
+const processor = postcss.plugin('postcss-modules-scope', function(options = {}) {
+  const rootDir = options.rootDir || process.cwd();
+
   return (css) => {
-    let generateScopedName = options && options.generateScopedName || processor.generateScopedName;
+    let generateScopedName = options.generateScopedName || processor.generateScopedName;
 
     let exports = {};
 
     function exportScopedName(name) {
-      let scopedName = generateScopedName(name, css.source.input.from, css.source.input.css);
+      let scopedName = generateScopedName(name, sep + relative(rootDir, css.source.input.from), css.source.input.css);
       exports[name] = exports[name] || [];
       if(exports[name].indexOf(scopedName) < 0) {
         exports[name].push(scopedName);

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -40,9 +40,9 @@ describe("test-cases", function() {
             return generateScopedName(exportedName, normalizedPath);
           }
         };
-        if(fs.existsSync(path.join(testDir, testCase, "config.json"))) {
-          config = JSON.parse(fs.readFileSync(path.join(testDir, testCase, "config.json"), "utf-8"));
-        }
+        try {
+          config = require(path.join(testDir, testCase, "config"));
+        } catch(e) {}
         if(fs.existsSync(path.join(testDir, testCase, "options.js"))) {
           options = require(path.join(testDir, testCase, "options.js"));
         }

--- a/test/test-cases/options-rootDir/config.js
+++ b/test/test-cases/options-rootDir/config.js
@@ -1,0 +1,5 @@
+var path = require('path');
+
+module.exports = {
+  from: path.join(__dirname, 'source.css')
+}

--- a/test/test-cases/options-rootDir/expected.css
+++ b/test/test-cases/options-rootDir/expected.css
@@ -1,0 +1,11 @@
+._options_rootDir_source__exportName {
+  color: green;
+}
+
+._options_rootDir_source__exportName:hover {
+  color: red;
+}
+
+:export {
+  exportName: _options_rootDir_source__exportName;
+}

--- a/test/test-cases/options-rootDir/options.js
+++ b/test/test-cases/options-rootDir/options.js
@@ -1,0 +1,5 @@
+var path = require('path');
+
+module.exports = {
+  rootDir: path.join(__dirname, '..')
+};

--- a/test/test-cases/options-rootDir/source.css
+++ b/test/test-cases/options-rootDir/source.css
@@ -1,0 +1,7 @@
+:local(.exportName) {
+  color: green;
+}
+
+:local(.exportName):hover {
+  color: red;
+}


### PR DESCRIPTION
I think we should provide real paths using [config.from](https://github.com/postcss/postcss/blob/master/docs/api.md#processorprocesscss-opts). Will be easier to use CSS Modules core plugins together with the other postcss plugins.

Also loader-core should be updated.
