### PR TITLE
Added global class composition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,11 +96,16 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
         let localNames = getSingleLocalNamesForComposes(selector);
         let classes = decl.value.split(/\s+/);
         classes.forEach((className) => {
-          if(hasOwnProperty.call(importedNames, className)) {
+          let global = /^global\(([^\)]+)\)$/.exec(className);
+          if (global) {
+            localNames.forEach((exportedName) => {
+              exports[exportedName].push(global[1]);
+            })
+          } else if (hasOwnProperty.call(importedNames, className)) {
             localNames.forEach((exportedName) => {
               exports[exportedName].push(className);
             });
-          } else if(hasOwnProperty.call(exports, className)) {
+          } else if (hasOwnProperty.call(exports, className)) {
             localNames.forEach((exportedName) => {
               exports[className].forEach((item) => {
                 exports[exportedName].push(item);
@@ -112,7 +117,7 @@ const processor = postcss.plugin('postcss-modules-scope', function(options) {
         });
         decl.remove();
       });
-      
+
       rule.walkDecls(decl => {
         var tokens = decl.value.split(/(,|'[^']*'|"[^"]*")/);
         tokens = tokens.map((token, idx) => {

--- a/test/test-cases/export-with-global-composes/config.json
+++ b/test/test-cases/export-with-global-composes/config.json
@@ -1,0 +1,3 @@
+{
+  "from": "/lib/extender.css"
+}

--- a/test/test-cases/export-with-global-composes/expected.css
+++ b/test/test-cases/export-with-global-composes/expected.css
@@ -1,0 +1,6 @@
+.otherClass { background: red; }
+.andAgain { font-size: 2em; }
+.aThirdClass { color: red; }
+._lib_extender__exportName { color: green; }
+:export {
+  exportName: _lib_extender__exportName otherClass andAgain aThirdClass; }

--- a/test/test-cases/export-with-global-composes/source.css
+++ b/test/test-cases/export-with-global-composes/source.css
@@ -1,0 +1,4 @@
+.otherClass { background: red; }
+.andAgain { font-size: 2em; }
+.aThirdClass { color: red; }
+:local(.exportName) { compose-with: global(otherClass) global(andAgain); compose-with: global(aThirdClass); color: green; }


### PR DESCRIPTION
Went with `composes: global(class-name)`. Going to add a rule in extract imports to enable `composes: class-name from global`
